### PR TITLE
Fan kickstart

### DIFF
--- a/src/ArduinoDUE/Repetier/HAL.cpp
+++ b/src/ArduinoDUE/Repetier/HAL.cpp
@@ -1141,6 +1141,11 @@ void PWM_TIMER_VECTOR ()
         if(pwm_pos_set[PWM_FAN1] == pwm_count_cooler && pwm_pos_set[PWM_FAN1] != COOLER_PWM_MASK) WRITE(FAN_PIN,0);
 #endif
     }
+    else
+    {
+    	// Explicitly set fan max speed while in kickstart interval.
+    	WRITE(FAN_PIN, 1);
+    }
 #endif
 #if FAN2_PIN > -1 && FEATURE_FAN2_CONTROL
 if(fan2Kickstart == 0)

--- a/src/ArduinoDUE/Repetier/Printer.cpp
+++ b/src/ArduinoDUE/Repetier/Printer.cpp
@@ -529,7 +529,7 @@ void Printer::setFanSpeedDirectly(uint8_t speed) {
     if(pwm_pos[PWM_FAN1] == speed)
         return;
 #if FAN_KICKSTART_TIME
-    if(fanKickstart == 0 && speed > pwm_pos[PWM_FAN1] && speed < 85)
+    if(fanKickstart == 0 && speed > pwm_pos[PWM_FAN1] && speed < 128)
     {
          if(pwm_pos[PWM_FAN1]) fanKickstart = FAN_KICKSTART_TIME / 100;
          else                  fanKickstart = FAN_KICKSTART_TIME / 25;


### PR DESCRIPTION
Hi Luc,
Congratulations for the excellent work!

I have recently flashed the FW in my old Da Vinci 1.0 and it literally gave it new life ...
However, after upgrading to a E3Dv6 extruder and using a feature fan on pin FAN_PIN I have realized that the fan kickstart feature does not work.

The commits in this branch fix the problem by explicitly setting the fan to the max speed during the kickstart time interval in the PWM timer handler.

It is also beneficial to raise the minimum speed below which the kickstart time is triggered from 33% to 50%, since the re-purposed stock extruder cooler fan in the Da Vinci does not start at 40% either.

Cheers,
Pasquale