### PR TITLE
Added thermistor table for semitec 104GT-2 in DaVinci 1.0.

### DIFF
--- a/Dv10-E3Dv6-ThermistorTable.py
+++ b/Dv10-E3Dv6-ThermistorTable.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import math, numpy as np, matplotlib.pyplot as plt
+
+
+# Vref---R2---+---RT---gnd
+#             |
+#             +---R1---gnd
+#             |
+#            Vadc
+
+class Thermistor:
+
+  def __init__ (self, R0_Ω, T0_C, β_K, R1, R2):
+    self.β_K = β_K
+    self.Ri = (R1 * R2) / (R1 + R2)
+    self.Kv = 4096 * R1 / (R1 + R2)
+    self.const = R0_Ω / math.exp (β_K / (T0_C + 273.15))
+
+  def resistance (self, T_C):
+    return self.const * math.exp (self.β_K / (T_C + 273.15)) 
+
+  def adc (self, T_C, RT_Ω=None):
+    if RT_Ω is None: RT_Ω = self.resistance (T_C)
+    return round (self.Kv * RT_Ω / (RT_Ω + self.Ri))
+
+
+class DaVinci10E3Dv6 (Thermistor):
+
+  def __init__ (self): # Semitec 104 GT-2
+    Thermistor.__init__ (self, 1e5, 25, 4267, 10000, 4700)
+    self.table = (
+        (-20, 1127000.0),
+        (-10,  620000.0),
+        (  0,  353700.0),
+        ( 10,  208600.0),
+        ( 20,  126800.0),
+        ( 30,   79360.0),
+        ( 40,   50960.0),
+        ( 50,   33490.0),
+        ( 60,   22510.0),
+        ( 70,   15440.0),
+        ( 80,   10800.0),
+        ( 90,    7686.0),
+        (100,    5556.0),
+        (110,    4082.0),
+        (120,    3043.0),
+        (130,    2298.0),
+        (140,    1758.0),
+        (150,    1360.0),
+        (160,    1064.0),
+        (170,     841.4),
+        (180,     671.4),
+        (190,     540.8),
+        (200,     439.3),
+        (210,     359.7),
+        (220,     296.9),
+        (230,     246.8),
+        (240,     206.5),
+        (250,     174.0),
+        (260,     147.5),
+        (270,     125.8),
+        (280,     107.9),
+        (290,     93.05),
+        (300,     80.65))
+
+  def print_map (self):
+    print ('#define EXT0_TEMPSENSOR_TYPE 7')
+    print (f'#define NUM_TEMPS_USERTHERMISTOR2 {len(self.table)}')
+    print ('#define USER_THERMISTORTABLE2 {', end = '')
+    for t, r in reversed(self.table):
+      a = self.adc(t, r) 
+      print (f'{{{a},{t*8}}},', end='')
+    print ('}')
+
+
+if __name__ == '__main__':
+
+  t = DaVinci10E3Dv6 ()
+  t.print_map()
+
+  print ('R@-20 =', t.resistance (-20), t.adc(-20))
+  print ('R@25  =', t.resistance (25),  t.adc(25))
+  print ('R@300 =', t.resistance (300), t.adc(300))
+
+  x = np.linspace (-20, 300, 33)
+  y = [t.adc(i) for i in x]
+  plt.plot(x, y)
+  plt.grid()
+  plt.show()
+

--- a/src/ArduinoDUE/Repetier/Configuration.h
+++ b/src/ArduinoDUE/Repetier/Configuration.h
@@ -726,9 +726,12 @@ If you have a PTC thermistor instead of a NTC thermistor, keep the adc values in
 #define NUM_TEMPS_USERTHERMISTOR1 19
 #define USER_THERMISTORTABLE1 {{628,1280},{859,1200},{1113,1120},{1382,1040},{1660,960},{1938,880},{2211,800},{2473,720},{2718,640},{2945,560},{3148,480},{3328,400},{3482,320},{3613,240},{3722,160},{3815,80},{3895,0},{3972,-80},{4055,-160}}
 
-/** Number of entries in the user thermistor table 2. Set to 0 to disable it. */
-#define NUM_TEMPS_USERTHERMISTOR2 0
-#define USER_THERMISTORTABLE2  {}
+// Custom table for DaVinci 1.0 with ATC semitec 104GT-2 thermistor and parallel R1=10kohm,
+// series R2=4.7kohm with resistor values taken from http://www.atcsemitec.co.uk/gt-2-glass-thermistors.html.
+// Table is computed with included Dv10-E3Dv6-ThermistorTable.py.
+// Turn on by setting EXT0_TEMPSENSOR_TYPE to 7 above. 
+#define NUM_TEMPS_USERTHERMISTOR2 33
+#define USER_THERMISTORTABLE2 {{69,2400},{79,2320},{91,2240},{105,2160},{123,2080},{144,2000},{169,1920},{200,1840},{237,1760},{282,1680},{337,1600},{403,1520},{484,1440},{581,1360},{696,1280},{832,1200},{989,1120},{1165,1040},{1359,960},{1563,880},{1769,800},{1968,720},{2150,640},{2308,560},{2440,480},{2544,400},{2622,320},{2678,240},{2718,160},{2744,80},{2761,0},{2772,-80},{2779,-160}}
 
 #else
 #define NUM_TEMPS_USERTHERMISTOR0 28


### PR DESCRIPTION
This branch adds support for the ATC semitec 104GT-2 thermistor that comes with the popular E3Dv6 extruder kit when installed in a Da Vinci 1.0 where the thermistor is in parallel to a resistor R1=10kohm, forming a voltage divider with a resistor R2=4.7kohm.
Thermistor values are taken from http://www.atcsemitec.co.uk/gt-2-glass-thermistors.html.

The thermistor sensor table is generated with the included Dv10-E3Dv6-ThermistorTable.py python script, and can be turned on by setting the macro EXT0_TEMPSENSOR_TYPE to 7. 

The same script can be easily used to generate other tables by changing thermistor data, R1, and R2.

Cheers,
Pasquale